### PR TITLE
[DM-42] Fix for Demos

### DIFF
--- a/deploy/example-config.json
+++ b/deploy/example-config.json
@@ -2,7 +2,7 @@
   "targets": {
     "dev": { 
       "outputPath": "public",
-      "publicPath" : "/public", 
+      "publicPath" : ".", 
       "assetModuleFilename" : "./public"
     }, 
     "prod": { 

--- a/src/pages/elevation-shadows.html
+++ b/src/pages/elevation-shadows.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Typography</title>
-    <link rel="stylesheet" href="/public/main.css">
+    <link rel="stylesheet" href="main.css">
     <style>
         .elev-box{
             padding: 2rem;

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Style Guide</title> 
-    <link rel="stylesheet" href="/public/main.css">
+    <link rel="stylesheet" href="main.css">
 <body>
     <h1 class="color--primary-color">Hello World</h1>
 </body>

--- a/src/pages/links.html
+++ b/src/pages/links.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Links</title>
-    <link rel="stylesheet" href="/public/main.css">
+    <link rel="stylesheet" href="main.css">
     <style>
 
     </style>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const config = require( './deploy/config.json' );
  
-const htmlFileRegex = new RegExp(/(src\/pages\/)/, 'ig');
+const htmlFileRegex = new RegExp(/(src\/pages\/)|(src\\pages\\)/, 'ig');
 let directories = config.entryPoints.pages.directory;
 
 let htmlFiles = [];


### PR DESCRIPTION
Fixes issue where developers had to add 'public/' to link CSS and JS in their demos. Note: this fix was overwritten and has to be submitted again.

To apply the patch: 
1. Stop the build watch process
2. Pull develop-major branch 
3. In Gitbash run $ cd deploy && cp example-config.json config.json
4. Run npm build 
5. Visit any of the .HTML files in the public/ directory (i.e. C:/../de-migration/public/grid.html)