### PR TITLE
[DM-6] Update Flex Grid Top and Bottom 

### DIFF
--- a/src/demos/flex-grid/index.html
+++ b/src/demos/flex-grid/index.html
@@ -11,7 +11,7 @@
 <body> 
   <!-- Mobile Columns -->
   <section> 
-    <div class="container fs--text-center bg--warning-background"> 
+    <div class="container fs--text-center "> 
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h1>Flex Grid<br><span class="heading-2">Standard Columns & Offsets</span></h1>
@@ -61,7 +61,7 @@
 
   <!-- Mobile Offsets -->
   <section>
-    <div class="container bg--warning-background fs--text-center">
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Mobile - Offset Columns</h3>
@@ -106,7 +106,7 @@
 
   <!-- Tablet Columns -->
   <section>
-    <div class="container bg--warning-background fs--text-center">
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Tablet - 8 Column Grid</h3>
@@ -179,7 +179,7 @@
    
   <!-- Tablet Offsets -->
   <section>
-    <div class="container bg--warning-background fs--text-center">
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Tablet - Offset Columns</h3>
@@ -252,7 +252,7 @@
  
   <!-- Tablet - Odd Number -->
   <section>
-    <div class="container bg--warning-background fs--text-center">
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Tablet - 9 Column Grid</h3>
@@ -365,7 +365,7 @@
   <!-- Tablet 9 - Column Offset -->
 
   <section>
-    <div class="container bg--warning-background fs--text-center">
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Tablet - Offset Columns</h3>
@@ -448,7 +448,7 @@
 
   <!-- Laptop Columns -->
   <section>
-    <div class="container bg--warning-background fs--text-center">
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Laptop - 12 Column Grid</h3>
@@ -552,8 +552,8 @@
   </section>
 
    <!-- Laptop Offsets -->
-   <section class="bg--white-base">
-    <div class="container bg--warning-background fs--text-center">
+   <section>
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Laptop - Offset Columns</h3>
@@ -659,7 +659,7 @@
 
   <!-- Desktop Columns -->
   <section>
-    <div class="container bg--warning-background fs--text-center">
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Desktop - 12 Column Grid</h3>
@@ -763,8 +763,8 @@
   </section>
 
    <!-- Desktop Offsets -->
-   <section class="bg--white-base">
-    <div class="container bg--warning-background fs--text-center">
+   <section>
+    <div class="container  fs--text-center">
       <div class="row bg--white-base">
         <div class="col--sm-4 no-border">
           <h3>Desktop - Offset Columns</h3>

--- a/src/styles/abstracts/base/_spacing-map.scss
+++ b/src/styles/abstracts/base/_spacing-map.scss
@@ -68,10 +68,10 @@ $spacing: (
         ), 
         "column" : ( 
             "top-mg" : (
-                "sm" : #{$v-spacing--200}, 
-                "md" : #{$v-spacing--200}, 
-                "lg" : #{$v-spacing--200}, 
-                "xl" : #{$v-spacing--200}, 
+                "sm" : #{$v-spacing--100}, 
+                "md" : #{$v-spacing--100}, 
+                "lg" : #{$v-spacing--100}, 
+                "xl" : #{$v-spacing--100}, 
             ),
             "btm-mg" :  (
                 "sm" : #{$v-spacing--100}, 

--- a/src/styles/layout/_container.scss
+++ b/src/styles/layout/_container.scss
@@ -2,12 +2,15 @@
 
 /*--- Layout - Container ---*/ 
 
-$multiplier: -1;
+$multiplier: -1;  
+$row-multiplier: -1; 
+$col-multiplier: 2; 
+
 .container {
     max-width: var(--max-content-width--s);
     padding-left: calc(#{$multiplier} * var(--container--gutter--sm)); 
     padding-right: calc(#{$multiplier} * var(--container--gutter--sm));
-    margin: 0 auto;
+    margin: calc(var(--gutter-sm) * ( #{$row-multiplier} * 2 )) auto;
 }  
 
 @include mediaQuery("tablet-up") {
@@ -15,6 +18,7 @@ $multiplier: -1;
         max-width: var(--max-content-width--m);  
         padding-left: calc(#{$multiplier} * var(--container--gutter--md)); 
         padding-right: calc(#{$multiplier} * var(--container--gutter--md));   
+        margin: calc(var(--gutter-sm) * ( #{$row-multiplier} * 2 )) auto;
     }  
 }
 
@@ -23,6 +27,7 @@ $multiplier: -1;
         max-width: var(--max-content-width--l);
         padding-left: calc(#{$multiplier} * var(--container--gutter--lg)); 
         padding-right: calc(#{$multiplier} * var(--container--gutter--lg));
+        margin: calc(var(--gutter-sm) * ( #{$row-multiplier} * 2 )) auto;
     }   
 }
 
@@ -31,6 +36,7 @@ $multiplier: -1;
         max-width: var(--max-content-width--xl);
         padding-left: calc(#{$multiplier} * var(--container--gutter--xl)); 
         padding-right: calc(#{$multiplier} * var(--container--gutter--xl));
+        margin: calc(var(--gutter-sm) * ( #{$row-multiplier} * 2 )) auto;
     }   
 }
 

--- a/src/styles/utilities/_flex-grid.scss
+++ b/src/styles/utilities/_flex-grid.scss
@@ -2,15 +2,21 @@
  
 /*--- Utilities - Flex Grid, Rows ---*/ 
 
-$multiplier: -1;
+$row-multiplier: -1; 
+$col-multiplier: 2;
 
 .row { 
-	margin-left: calc(var(--gutter-sm) * #{$multiplier});
-	margin-right: calc(var(--gutter-sm) * #{$multiplier}); 
+	margin-left: calc(var(--gutter-sm) * #{$row-multiplier});
+	margin-right: calc(var(--gutter-sm) * #{$row-multiplier});  
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
 } 
+ 
+.row[class*=bg] .col {
+	padding-left: calc(var(--gutter-sm) * #{$col-multiplier});
+	padding-right: calc(var(--gutter-sm) * #{$col-multiplier}); 
+}
  
 .row.even-3--sm > [class*=col] { flex: 0 1 calc((100%/3) * 1); }
 .row.even-4--sm > [class*=col] { flex: 0 1 calc((100%/4) * 1); }
@@ -18,8 +24,13 @@ $multiplier: -1;
 @include mediaQuery("tablet-up") {
  
 	.row {
-		margin-left: calc(var(--gutter-md) * #{$multiplier});
-		margin-right: calc(var(--gutter-md) * #{$multiplier});
+		margin-left: calc(var(--gutter-md) * #{$row-multiplier});
+		margin-right: calc(var(--gutter-md) * #{$row-multiplier});
+	} 
+
+	.row[class*=bg] .col {
+		padding-left: calc(var(--gutter-md) * #{$col-multiplier});
+		padding-right: calc(var(--gutter-md) * #{$col-multiplier});
 	}
 
 	.row.even-5--md > [class*=col] { flex: 0 1 calc((100%/5) * 1); } 
@@ -30,8 +41,13 @@ $multiplier: -1;
 @include mediaQuery("laptop-up") {
 
 	.row {
-		margin-left: calc(var(--gutter-lg) * #{$multiplier});
-		margin-right: calc(var(--gutter-lg) * #{$multiplier});
+		margin-left: calc(var(--gutter-lg) * #{$row-multiplier});
+		margin-right: calc(var(--gutter-lg) * #{$row-multiplier});
+	}
+
+	.row[class*=bg] .col {
+		padding-left: calc(var(--gutter-lg) * #{$col-multiplier});
+		padding-right: calc(var(--gutter-lg) * #{$col-multiplier});
 	}
 
 	.row.even-12--lg > [class*=col] { flex: 0 1 calc((100%/12) * 1); }
@@ -41,13 +57,18 @@ $multiplier: -1;
 @include mediaQuery("desktop-up") {
 
 	.row {
-		margin-left: calc(var(--gutter-xl) * #{$multiplier});
-		margin-right: calc(var(--gutter-xl) * #{$multiplier});
+		margin-left: calc(var(--gutter-xl) * #{$row-multiplier});
+		margin-right: calc(var(--gutter-xl) * #{$row-multiplier});
+	}
+
+	.row[class*=bg] .col {
+		padding-left: calc(var(--gutter-xl) * #{$col-multiplier});
+		padding-right: calc(var(--gutter-xl) * #{$col-multiplier});
 	}
     
 	.row.even-12--xl > [class*=col] { flex: 0 1 calc((100%/12) * 1); }
 
-}
+} 
 
 /*--- Utilities - Flex Grid, Gutters ---*/
 
@@ -61,7 +82,10 @@ $multiplier: -1;
 [class*=col],
 [class*=col--] {
 	flex: 0 1 100%;
-}
+} 
+
+.row > .row [class*=col]:first-child { margin-top: 0; }
+.row > .row [class*=col]:last-child { margin-bottom: 0; }
 
 /*--- Utilities - Flex Grid, Vertical Spacing ---*/
 


### PR DESCRIPTION
Removes spacing in excess of 80px between sections by adding negative margin to container element to negate 16px top and bottom margin on containers

Before - Gap heading and section
![image](https://user-images.githubusercontent.com/125409868/225694698-3a53e49b-7425-4966-a406-a6e7bf032677.png)

After - Gap gone
![image](https://user-images.githubusercontent.com/125409868/225693846-82d5ef6a-ddc7-4870-8995-f43ca73928d1.png)
