### PR TITLE
[DM-156] Fixes Section Spacing

### DIFF
--- a/src/pages/demos/icon-usage/index.html
+++ b/src/pages/demos/icon-usage/index.html
@@ -26,7 +26,8 @@
         <link
             rel="stylesheet"
             href="../../assets/styles/regular.css"
-        />
+        /> 
+        <script src="icon-usage/index.html.js"></script>
     </head>
     <body>
         <section class="bg--tertiary-base">
@@ -178,132 +179,134 @@
         <section class="bdr-bottom">
             <div class="container bdr-clr--secondary-light-3">
                 <div class="row">
-                    <div class="col">
+                    <div class="col--md-4 mg-b--0 mg-t--0"> 
                         <div class="row">
-                            <div class="col--md-4">
-                                <div class="col fs--text-center">
-                                    <h4>Small Icons</h4>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--primary-base"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--primary-light-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--primary-light-2"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--primary-light-3"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--primary-dark-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--primary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-sm fak fa-circle-check-solid clr--secondary-base"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--secondary-light-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--secondary-light-2"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--secondary-light-3"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--secondary-dark-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--secondary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-sm fak fa-circle-check-solid clr--tertiary-base"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--tertiary-light-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--tertiary-light-2"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--tertiary-dark-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--tertiary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-sm fak fa-circle-check-solid clr--success-element"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--warning-element"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--error-element"></i>
-                                    <i class="icon-sm fak fa-circle-check-solid clr--info-element"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-sm fak fa-circle-check-light bg--primary-base"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--primary-light-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--primary-light-2"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--primary-light-3"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--primary-dark-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--primary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-sm fak fa-circle-check-light bg--secondary-base"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--secondary-light-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--secondary-light-2"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--secondary-light-3"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--secondary-dark-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--secondary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-sm fak fa-circle-check-light bg--tertiary-base"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--tertiary-light-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--tertiary-light-2"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--tertiary-dark-1"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--tertiary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-sm fak fa-circle-check-light bg--success-background"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--warning-background"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--error-background"></i>
-                                    <i class="icon-sm fak fa-circle-check-light bg--info-background"></i>
-                                </div>
+                            <div class="col fs--text-center">
+                                <h4>Small Icons</h4>
+                                <i class="icon-sm fak fa-circle-check-solid clr--primary-base"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--primary-light-1"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--primary-light-2"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--primary-light-3"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--primary-dark-1"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--primary-dark-2"></i>
                             </div>
-                            <div class="col--md-4">
-                                <div class="col fs--text-center">
-                                    <h4>Medium Icons</h4>
-                                    <i class="icon-md fak fa-circle-check-solid clr--primary-base"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--primary-light-1"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--primary-light-2"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--primary-light-3"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--primary-dark-1"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--primary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-md fak fa-circle-check-solid clr--secondary-base"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--secondary-light-1"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--secondary-light-2"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--secondary-light-3"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--secondary-dark-1"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--secondary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-md fak fa-circle-check-solid clr--tertiary-base"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--tertiary-light-1"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--tertiary-light-2"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--tertiary-dark-1"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--tertiary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-md fak fa-circle-check-solid clr--success-element"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--warning-element"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--error-element"></i>
-                                    <i class="icon-md fak fa-circle-check-solid clr--info-element"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-md fak fa-circle-check-light bg--primary-base"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--primary-light-1"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--primary-light-2"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--primary-light-3"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--primary-dark-1"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--primary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-md fak fa-circle-check-light bg--secondary-base"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--secondary-light-1"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--secondary-light-2"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--secondary-light-3"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--secondary-dark-1"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--secondary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-md fak fa-circle-check-light bg--tertiary-base"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--tertiary-light-1"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--tertiary-light-2"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--tertiary-dark-1"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--tertiary-dark-2"></i>
-                                </div>
-                                <div class="col fs--text-center">
-                                    <i class="icon-md fak fa-circle-check-light bg--success-background"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--warning-background"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--error-background"></i>
-                                    <i class="icon-md fak fa-circle-check-light bg--info-background"></i>
-                                </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-sm fak fa-circle-check-solid clr--secondary-base"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--secondary-light-1"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--secondary-light-2"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--secondary-light-3"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--secondary-dark-1"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--secondary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-sm fak fa-circle-check-solid clr--tertiary-base"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--tertiary-light-1"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--tertiary-light-2"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--tertiary-dark-1"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--tertiary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-sm fak fa-circle-check-solid clr--success-element"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--warning-element"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--error-element"></i>
+                                <i class="icon-sm fak fa-circle-check-solid clr--info-element"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-sm fak fa-circle-check-light bg--primary-base"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--primary-light-1"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--primary-light-2"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--primary-light-3"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--primary-dark-1"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--primary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-sm fak fa-circle-check-light bg--secondary-base"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--secondary-light-1"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--secondary-light-2"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--secondary-light-3"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--secondary-dark-1"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--secondary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-sm fak fa-circle-check-light bg--tertiary-base"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--tertiary-light-1"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--tertiary-light-2"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--tertiary-dark-1"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--tertiary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-sm fak fa-circle-check-light bg--success-background"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--warning-background"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--error-background"></i>
+                                <i class="icon-sm fak fa-circle-check-light bg--info-background"></i>
                             </div>
                         </div>
                     </div>
+                    <div class="col--md-4 mg-b--0 mg-t--0"> 
+                        <div class="row">
+                            <div class="col fs--text-center">
+                                <h4>Medium Icons</h4>
+                                <i class="icon-md fak fa-circle-check-solid clr--primary-base"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--primary-light-1"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--primary-light-2"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--primary-light-3"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--primary-dark-1"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--primary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-md fak fa-circle-check-solid clr--secondary-base"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--secondary-light-1"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--secondary-light-2"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--secondary-light-3"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--secondary-dark-1"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--secondary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-md fak fa-circle-check-solid clr--tertiary-base"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--tertiary-light-1"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--tertiary-light-2"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--tertiary-dark-1"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--tertiary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-md fak fa-circle-check-solid clr--success-element"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--warning-element"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--error-element"></i>
+                                <i class="icon-md fak fa-circle-check-solid clr--info-element"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-md fak fa-circle-check-light bg--primary-base"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--primary-light-1"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--primary-light-2"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--primary-light-3"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--primary-dark-1"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--primary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-md fak fa-circle-check-light bg--secondary-base"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--secondary-light-1"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--secondary-light-2"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--secondary-light-3"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--secondary-dark-1"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--secondary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-md fak fa-circle-check-light bg--tertiary-base"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--tertiary-light-1"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--tertiary-light-2"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--tertiary-dark-1"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--tertiary-dark-2"></i>
+                            </div>
+                            <div class="col fs--text-center">
+                                <i class="icon-md fak fa-circle-check-light bg--success-background"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--warning-background"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--error-background"></i>
+                                <i class="icon-md fak fa-circle-check-light bg--info-background"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
                     <div class="col fs--text-center">
                         <h4>Large Icons</h4>
                         <i class="icon-lg fak fa-circle-check-solid clr--primary-base"></i>

--- a/src/pages/demos/icon-usage/index.js
+++ b/src/pages/demos/icon-usage/index.js
@@ -1,0 +1,1 @@
+import '../../../styles/main.scss';

--- a/src/styles/abstracts/mixins/_spacing.scss
+++ b/src/styles/abstracts/mixins/_spacing.scss
@@ -13,11 +13,11 @@
             padding-left: calc(var(--gutter-#{$screenSize}) * 4);
             padding-right: calc(var(--gutter-#{$screenSize}) * 4);
         }
-        section:first-child {
+        section:first-of-type {
             margin: 0;
             padding-top: var(--sect--top-pd--#{$screenSize});
         }
-        section:last-child {
+        section:last-of-type {
             padding-bottom: var(--sect--btm-pd--#{$screenSize});
         }
 

--- a/src/styles/utilities/_flex-grid.scss
+++ b/src/styles/utilities/_flex-grid.scss
@@ -111,11 +111,6 @@ $col-multiplier: 2;
 @include getColumnMgBtm('desktop-up', 'lg');
 @include getColumnMgBtm('desktop-xl-up', 'xl');
 
-[class*='col'] > [class*='col'],
-[class*='col--'] > [class*='col--'] {
-    margin-bottom: 0;
-}
-
 @include getColumns('mobile-up', 'sm-odd', 3);
 @include getColumns('mobile-up', 'sm', 4);
 @include getColumns('mobile-landscape-up', 'md-odd', 9);


### PR DESCRIPTION
Noticed issues with section spacing on the icon-usage demo. This fix 

To fix this [Fix section spacing by removing the Flex-grid rule that strips the margin-bottom from nested columns. Additionally, transitioned selectors for first-child and last-child to first-of-type and last-of-type to account for situations where a section is not the first-child or the last-child

![image](https://user-images.githubusercontent.com/125409868/235587144-d003b3f4-4dbc-48ec-9d3b-b699828f3fb5.png)

https://nrg-juzzell.github.io/demos/icon-usage/