### PR TITLE
[DM-157] Remove Outline from Buttons on Hover

### DIFF
--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -88,11 +88,6 @@ button[class*='btn--secondary'],
     border-width: #{$btn--border-width};
     border-style: solid;
 
-    &:hover {
-        outline: #{$outline--focus};
-        outline-offset: #{$outline--focus-offset};
-    }
-
     &:focus {
         outline: #{$outline--focus};
         outline-offset: #{$outline--focus-offset};


### PR DESCRIPTION
Fixes an issue where the focus state appears on button hover. 

https://nrg-juzzell.github.io/demos/buttons/