### PR TITLE
Feature [DM-168]  - Remove the 'bg--tertiary-light-3' to fix the card components

### DIFF
--- a/src/config/cardsData.tsx
+++ b/src/config/cardsData.tsx
@@ -140,7 +140,7 @@ export const cardsbodyright: CardProps[] = [
         title,
         description: `${descriptionShort}`,
         cardDivClassName: 'col--lg-4 card-container',
-        cardClassName: 'card bg--tertiary-light-3',
+        cardClassName: 'card ',
         buttonClassName: 'btn--tertiary',
     },
     {
@@ -148,7 +148,7 @@ export const cardsbodyright: CardProps[] = [
         title,
         description: `${descriptionMedium}`,
         cardDivClassName: 'col--lg-4 card-container',
-        cardClassName: 'card bg--tertiary-light-3',
+        cardClassName: 'card ',
         buttonClassName: 'btn--tertiary',
     },
     {
@@ -156,7 +156,7 @@ export const cardsbodyright: CardProps[] = [
         title,
         description: `${descriptionLong}`,
         cardDivClassName: 'col--lg-4 card-container',
-        cardClassName: 'card bg--tertiary-light-3',
+        cardClassName: 'card ',
         buttonClassName: 'btn--tertiary',
     },
 ];

--- a/src/pages/demos/cards/index.html
+++ b/src/pages/demos/cards/index.html
@@ -42,7 +42,10 @@
             rel="stylesheet"
             href="../../assets/styles/light.css"
         />
-        <link rel="icon" href="../../assets/images/favicon.ico">
+        <link
+            rel="icon"
+            href="../../assets/images/favicon.ico"
+        />
     </head>
 
     <body>
@@ -263,7 +266,7 @@
                                     alt="card-img"
                                 />
                             </div>
-                            <div class="card-body bg--tertiary-light-3">
+                            <div class="card-body">
                                 <h4> <i class="icon-md fak fa-circle-check-light"></i>What's in it for Me?</h4>
                                 <p> At Direct Energy, your n</p>
                                 <button
@@ -378,7 +381,7 @@
                         </p>
                         <div class="row card-group">
                             <div class="col--lg-4 card-container">
-                                <div class="card bg--tertiary-light-3">
+                                <div class="card">
                                     <div class="card-body">
                                         <h4> <i class="icon-md fak fa-circle-check-light"></i>What's in it for Me?</h4>
                                         <p> At Direct Energy, your n</p>
@@ -392,7 +395,7 @@
                             </div>
 
                             <div class="col--lg-4 card-container">
-                                <div class="card bg--tertiary-light-3">
+                                <div class="card">
                                     <div class="card-body">
                                         <h4> <i class="icon-md fak fa-circle-check-light"></i>What's in it for Me?</h4>
                                         <p>
@@ -410,7 +413,7 @@
                             </div>
 
                             <div class="col--lg-4 card-container">
-                                <div class="card bg--tertiary-light-3">
+                                <div class="card">
                                     <div class="card-body">
                                         <h4> <i class="icon-md fak fa-circle-check-light"></i>What's in it for Me?</h4>
                                         <p>


### PR DESCRIPTION
To ensure consistency within our design system, we need to eliminate the color variation of the tertiary -light-3 design token from our card components.
https://nrg-susanruan.github.io/demos/cards/
https://nrg-susanruan.github.io/demos/react-cards/

It was:
<img width="1138" alt="Screen Shot 2023-07-06 at 10 07 39 PM" src="https://github.com/DE-UI-UX-Dev-Team/de-migration/assets/137719129/61c45986-501b-4843-a67a-056e8689abab">
<img width="1141" alt="Screen Shot 2023-07-06 at 10 07 30 PM" src="https://github.com/DE-UI-UX-Dev-Team/de-migration/assets/137719129/fcc1a444-39b2-419b-a209-b69374403ec3">

Updated:
<img width="1008" alt="Screen Shot 2023-07-10 at 2 13 08 PM" src="https://github.com/DE-UI-UX-Dev-Team/de-migration/assets/137719129/23de2fad-a3e6-4113-b3ae-d7f57bf6ba2d">
<img width="1032" alt="Screen Shot 2023-07-10 at 2 13 00 PM" src="https://github.com/DE-UI-UX-Dev-Team/de-migration/assets/137719129/2cee5200-4abc-4f50-a3b3-748ca1dfd3c5">


